### PR TITLE
Add new feature about sampling weather 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.7"
           - "1.8"
           - "nightly"
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Statistics = "1"
 Tables = "1"
 Term = "1, 2"
 YAML = "0.4"
-julia = "1.7"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.1"
 manifest_format = "2.0"
-project_hash = "3e6b9d83e4e1344d09539e3bbfb0e1be00f206a4"
+project_hash = "28ce73fcfa5346f0e97f67c55d9a310adbe02385"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.3"
+julia_version = "1.12.1"
 manifest_format = "2.0"
-project_hash = "b9f84d0b4866e06ee850d199fc16c20d112ef4b6"
+project_hash = "3e6b9d83e4e1344d09539e3bbfb0e1be00f206a4"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -16,13 +16,15 @@ version = "0.4.5"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.BitFlags]]
 git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
@@ -37,21 +39,21 @@ version = "0.10.15"
 
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
-git-tree-sha1 = "7eee164f122511d3e4e1ebadb7956939ea7e1c77"
+git-tree-sha1 = "b7231a755812695b8046e8471ddc34c8268cbad5"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "1.3.6"
+version = "3.0.0"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.6"
+version = "0.7.8"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.16.0"
+version = "4.18.1"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -60,13 +62,13 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.0+1"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "ea32b83ca4fefa1768dc84e504cc0a94fb1ab8d1"
+git-tree-sha1 = "d9d26935a0bcffc87d2613ce14c527c99fc543fd"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.4.2"
+version = "2.5.0"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -80,15 +82,15 @@ version = "1.16.0"
 
 [[deps.DataFrames]]
 deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
+git-tree-sha1 = "d8928e9169ff76c6281f39a659f9bca3a573f24c"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.7.0"
+version = "1.8.1"
 
 [[deps.DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
+deps = ["OrderedCollections"]
+git-tree-sha1 = "e357641bb3e0638d353c4b29ea0e40ea644066a6"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.20"
+version = "0.19.3"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -98,18 +100,18 @@ version = "1.0.0"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+version = "0.9.5"
 
 [[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "d0ea2c044963ed6f37703cead7e29f70cba13d7e"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "b37458ae37d8bdb643d763451585cd8d0e5b4a9e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.8.0"
+version = "1.16.1"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -124,15 +126,15 @@ version = "0.1.11"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "cc5231d52eb1771251fbd37171dbc408bcc8a1b6"
+git-tree-sha1 = "27af30de8b5445644e8ffe3bcb0d72049c089cf1"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.4+0"
+version = "2.7.3+0"
 
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates"]
-git-tree-sha1 = "7878ff7172a8e6beedd1dea14bd27c3c6340d361"
+git-tree-sha1 = "3bab2c5aa25e7840a4b065805c0cdfc01f3068d2"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
-version = "0.9.22"
+version = "0.9.24"
 weakdeps = ["Mmap", "Test"]
 
     [deps.FilePathsBase.extensions]
@@ -141,28 +143,36 @@ weakdeps = ["Mmap", "Test"]
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
 
 [[deps.Git]]
-deps = ["Git_jll"]
-git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.1"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "bb8471f313ed941f299aa53d32a94ab3bee08844"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.0+0"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
+git-tree-sha1 = "dc34a3e3d96b4ed305b641e626dc14c12b7824b8"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.46.2+0"
+version = "2.53.0+0"
 
 [[deps.HTTP]]
-deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "1336e07ba2eb75614c99496501a8f4b233e9fafe"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "5e6fe50ae7f23d171f44e311c2960294aaa0beb5"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.10.10"
+version = "1.10.19"
 
 [[deps.Highlights]]
 deps = ["DocStringExtensions", "InteractiveUtils", "REPL"]
@@ -172,14 +182,14 @@ version = "0.5.3"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "b6d6bfdd7ce25b0f9b2f6b3dd56b2673a66c8770"
+git-tree-sha1 = "0ee181ec08df7d7c911901ea38baf16f755114dc"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.5"
+version = "1.0.0"
 
 [[deps.InlineStrings]]
-git-tree-sha1 = "45521d31238e87ee9f9732561bfee12d4eebd52d"
+git-tree-sha1 = "8f3d257792a522b4601c24a577954b0a8cd7334d"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.4.2"
+version = "1.4.5"
 
     [deps.InlineStrings.extensions]
     ArrowTypesExt = "ArrowTypes"
@@ -192,11 +202,12 @@ version = "1.4.2"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.InvertedIndices]]
-git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
+git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -205,15 +216,20 @@ version = "1.0.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.6.1"
+version = "1.7.1"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
@@ -231,49 +247,54 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.11.1+1"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "61dfdba58e585066d8bce214c5a51eaa0539f269"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+1"
+version = "1.18.0+0"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.LoggingExtras]]
 deps = ["Dates", "Logging"]
-git-tree-sha1 = "f02b56007b064fbfddb4c9cd60161b6dd0f40df3"
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-version = "1.1.0"
+version = "1.2.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MarkdownAST]]
 deps = ["AbstractTrees", "Markdown"]
@@ -288,9 +309,10 @@ uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.1.9"
 
 [[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
+version = "2.28.1010+0"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -300,10 +322,11 @@ version = "1.2.0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.5.20"
 
 [[deps.MyterialColors]]
 git-tree-sha1 = "01d8466fb449436348999d7c6ad740f8f853a579"
@@ -312,34 +335,39 @@ version = "0.3.0"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.29+0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "301412a644646fdc0ad67d0a87487466b491e53d"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.2.1+0"
 
 [[deps.OpenSSL]]
-deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
-git-tree-sha1 = "38cb508d080d21dc1128f7fb04f20387ed4c0af4"
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
 uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-version = "1.4.3"
+version = "1.6.1"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+1"
+version = "3.5.1+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.3"
+version = "1.8.1"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -349,20 +377,24 @@ version = "0.12.3"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.1"
+version = "2.8.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.12.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
 
 [[deps.PlantMeteo]]
 deps = ["CSV", "Crayons", "DataAPI", "DataFrames", "Dates", "HTTP", "JSON", "PrettyTables", "Statistics", "Tables", "Term", "YAML"]
 path = ".."
 uuid = "4630fe09-e0fb-4da5-a846-781cb73437b6"
-version = "0.6.0"
+version = "0.6.1"
 
 [[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
@@ -372,15 +404,15 @@ version = "1.4.3"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.1"
+version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.1"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
@@ -391,20 +423,23 @@ version = "2.4.0"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.ProgressLogging]]
 deps = ["Logging", "SHA", "UUIDs"]
-git-tree-sha1 = "80d919dee55b9c50e8d9e2da5eeafff3fe58b539"
+git-tree-sha1 = "f0803bc1171e455a04124affa9c21bba5ac4db32"
 uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
-version = "0.1.4"
+version = "0.1.6"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -423,12 +458,13 @@ version = "0.7.0"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
-git-tree-sha1 = "d0553ce4031a081cc42387a9b9c8441b7d99f32d"
+git-tree-sha1 = "ebe7e59b37c400f694f52b58c93d26201387da70"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.4.7"
+version = "1.4.9"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.SimpleBufferStream]]
 git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
@@ -437,22 +473,25 @@ version = "1.2.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "66e0a8e672a0bdfca2c3f5937efb8538b9ddc085"
+git-tree-sha1 = "64d974c2e6fdf07f8155b5b2ca2ffa9069b608d9"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.2.1"
-
-[[deps.SparseArrays]]
-deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.10.0"
+version = "1.2.2"
 
 [[deps.Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.10.0"
+version = "1.11.1"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.StringEncodings]]
 deps = ["Libiconv_jll"]
@@ -462,14 +501,13 @@ version = "0.3.7"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "a6b1675a536c5ad1a60e5a5153e1fee12eb146e3"
+git-tree-sha1 = "a3c1536470bf8c5e02096ad4853606d7c8f62721"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.0"
+version = "0.4.2"
 
-[[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
-uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.2.1+1"
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -484,9 +522,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
-git-tree-sha1 = "598cd7c1f68d1e205689b1c2fe65a9f85846f297"
+git-tree-sha1 = "f2c1efbc8f3a609aadf318094f8fc5204bdaf344"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.12.0"
+version = "1.12.1"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -495,13 +533,14 @@ version = "1.10.0"
 
 [[deps.Term]]
 deps = ["AbstractTrees", "CodeTracking", "Dates", "Highlights", "InteractiveUtils", "Logging", "Markdown", "MyterialColors", "OrderedCollections", "Parameters", "PrecompileTools", "ProgressLogging", "REPL", "Tables", "UUIDs", "Unicode", "UnicodeFun"]
-git-tree-sha1 = "387e63d0b12d43982a3aacaef81cbbfb465715ae"
+git-tree-sha1 = "dfb5cd0af7f67f7487287fa7f83860fe0cb45899"
 uuid = "22787eb5-b846-44ae-b979-8e399b8463ab"
-version = "2.0.6"
+version = "2.0.8"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -509,13 +548,14 @@ uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.11.3"
 
 [[deps.URIs]]
-git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.5.1"
+version = "1.6.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.UnPack]]
 git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
@@ -524,6 +564,7 @@ version = "1.0.2"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.UnicodeFun]]
 deps = ["REPL"]
@@ -544,26 +585,26 @@ version = "1.6.1"
 
 [[deps.YAML]]
 deps = ["Base64", "Dates", "Printf", "StringEncodings"]
-git-tree-sha1 = "dea63ff72079443240fbd013ba006bcbc8a9ac00"
+git-tree-sha1 = "a1c0c7585346251353cddede21f180b96388c403"
 uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-version = "0.4.12"
+version = "0.4.16"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+1"
+version = "5.15.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.5.0+2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PlantMeteo = "4630fe09-e0fb-4da5-a846-781cb73437b6"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
 using PlantMeteo
 using Documenter
-using Dates
+using Dates, Statistics
 
-DocMeta.setdocmeta!(PlantMeteo, :DocTestSetup, :(using PlantMeteo, Dates); recursive=true)
+DocMeta.setdocmeta!(PlantMeteo, :DocTestSetup, :(using PlantMeteo, Dates, Statistics); recursive=true)
 
 makedocs(;
     modules=[PlantMeteo],
@@ -17,6 +17,11 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Getting Started" => "getting-started.md",
+        "Guides" => [
+            "Weather Data Sources" => "weather-apis.md",
+            "Weather Sampling" => "weather-sampling.md",
+        ],
         "API" => "API.md"
     ]
 )

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -85,8 +85,8 @@ meteo_hourly = Weather([
 ])
 
 prepared = prepare_weather_sampler(meteo_hourly)
-spec = MeteoSamplingSpec(24.0)  # rolling 24-source-step window
-sampled = sample_weather(prepared, 24; spec = spec)
+window = RollingWindow(24.0)  # trailing 24-source-step window
+sampled = sample_weather(prepared, 24; window = window)
 
 # Get the temperature from the sampled row, which is a daily-averaged value of the 24 hourly source steps:
 (;sampled.duration, sampled.date, sampled.T)
@@ -101,11 +101,11 @@ mean(meteo_hourly[i].T for i in 1:24)
 
 ## 4. Precompute Sampling for Whole Runs
 
-Avoid repeated sampling work in long simulation loops, and get a cached sampled table for each requested sampling spec:
+Avoid repeated sampling work in long simulation loops, and get a cached sampled table for each requested sampling window:
 
 ```@example getting_started
-tables = materialize_weather(prepared; specs = [spec])
-daily_like = tables[spec]
+tables = materialize_weather(prepared; windows = [window])
+daily_like = tables[window]
 
 (length(daily_like), daily_like[24].T ≈ sampled.T, length(meteo_hourly))
 ```
@@ -121,7 +121,7 @@ custom_transforms = (
     Tsum = (source = :T, reducer = SumReducer())
 )
 
-custom_row = sample_weather(prepared, 24; spec = spec, transforms = custom_transforms)
+custom_row = sample_weather(prepared, 24; window = window, transforms = custom_transforms)
 (custom_row.T, custom_row.Tmax, custom_row.Tsum)
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,132 @@
+```@meta
+CurrentModule = PlantMeteo
+```
+
+# Getting Started
+
+This tutorial introduces the package through a realistic first workflow.
+
+## Goal
+
+By the end, you will have:
+
+- loaded weather into a `Weather` table
+- inspected the standardized variables
+- aggregated fine-step weather into model-friendly steps
+
+## Why This Matters
+
+Most weather workflows fail at the interface between raw data and model expectations:
+
+- columns are named differently across sources
+- durations and timestamps are not consistently encoded
+- model clocks rarely match source resolution
+
+The examples below show how PlantMeteo addresses these issues step by step.
+
+## 1. Read and Standardize a Weather File
+
+Convert heterogeneous input columns into `Atmosphere`-compatible variables and get a typed weather table (`TimeStepTable{Atmosphere}`) with known fields:
+
+```@example getting_started
+using PlantMeteo
+using Dates
+
+file = joinpath(dirname(dirname(pathof(PlantMeteo))), "test", "data", "meteo.csv")
+
+meteo = read_weather(
+    file,
+    :temperature => :T,
+    :relativeHumidity => (x -> x ./ 100) => :Rh,
+    :wind => :Wind,
+    :atmosphereCO2_ppm => :Cₐ,
+    date_format = DateFormat("yyyy/mm/dd")
+)
+
+meteo
+```
+
+## 2. Inspect the Data You Will Feed to Models
+
+Each row is an `Atmosphere`. You can get a row by indexing the table with a single index:
+
+```@example getting_started
+first_row = meteo[1]
+first_row
+```
+
+And because PlantMeteo implements the Tables.jl interface, table columns are easy to inspect and manipulate like a DataFrame.
+For example to get the temperature column as a vector:
+
+```@example getting_started
+meteo.T
+```
+
+## 3. Sample Weather to Match a Model Time Step
+
+Sometimes models require weather at a coarser time step than the source data. For example, you may have hourly weather but want daily values for a crop model. PlantMeteo's sampling functions let you aggregate weather from source resolution to model resolution, and get an aggregated `Atmosphere` row per query step.
+
+For example we can build a fake 2-day hourly series and sample it to get a daily-like `Atmosphere` for the 24th hour, using a rolling 24-source-step window:
+
+```@example getting_started
+# Build a longer hourly series for sampling demonstrations.
+base = DateTime(2025, 1, 1)
+meteo_hourly = Weather([
+    Atmosphere(
+        date = base + Hour(i),
+        duration = Hour(1),
+        T = 10.0 + i,
+        Wind = 1.0,
+        Rh = 0.55,
+        P = 100.0,
+        Ri_SW_f = 200.0
+    )
+    for i in 0:47
+])
+
+prepared = prepare_weather_sampler(meteo_hourly)
+spec = MeteoSamplingSpec(24.0)  # rolling 24-source-step window
+sampled = sample_weather(prepared, 24; spec = spec)
+
+# Get the temperature from the sampled row, which is a daily-averaged value of the 24 hourly source steps:
+(;sampled.duration, sampled.date, sampled.T)
+```
+
+This value is the mean of the 24 hourly temperatures from the source data, which matches our expectation for a daily-like sample:
+
+```@example getting_started
+using Statistics
+mean(meteo_hourly[i].T for i in 1:24)
+```
+
+## 4. Precompute Sampling for Whole Runs
+
+Avoid repeated sampling work in long simulation loops, and get a cached sampled table for each requested sampling spec:
+
+```@example getting_started
+tables = materialize_weather(prepared; specs = [spec])
+daily_like = tables[spec]
+
+(length(daily_like), daily_like[24].T ≈ sampled.T, length(meteo_hourly))
+```
+
+## 5. Override Default Sampling Rules (Optional)
+
+Encode model-specific aggregation rules per variable. Transforms are normalized and applied for the current call:
+
+```@example getting_started
+custom_transforms = (
+    T = MeanWeighted(),
+    Tmax = (source = :T, reducer = MaxReducer()),
+    Tsum = (source = :T, reducer = SumReducer())
+)
+
+custom_row = sample_weather(prepared, 24; spec = spec, transforms = custom_transforms)
+(custom_row.T, custom_row.Tmax, custom_row.Tsum)
+```
+
+## Next Steps
+
+- [Weather Data Sources](weather-apis.md): deeper look at file/API ingestion and export.
+- [Weather Sampling](weather-sampling.md): windows, reducers, transforms, and caching strategy.
+- [API](API.md): full reference for all exported symbols.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,43 +9,44 @@ CurrentModule = PlantMeteo
 [![Build Status](https://github.com/PalmStudio/PlantMeteo.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/PalmStudio/PlantMeteo.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/PalmStudio/PlantMeteo.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/VEZY/PlantMeteo.jl)
 
-## Overview
+## What Problem This Package Solves
 
-`PlantMeteo` is for everything related to meteorological/climatic data related to plant growth. 
+Plant models often consume weather data from very different sources:
 
-The package gives users access to useful and efficient structures, functions for reading and computing data and easy connection to weather APIs:
+- station files with inconsistent column names and units
+- API data with provider-specific schemas
+- time steps that do not match your model clock (hourly input, daily model, multi-rate simulation)
 
-- [`TimeStepTable`](@ref) to define efficient tables
-- [`Atmosphere`](@ref) to automatically compute atmosphere-related variables from a set of variables
-- [`Constants`](@ref) that provide default values for physical constants (*e.g.* the universal gas constant or the latent heat of vaporization of water)
-- helper functions such as [`vapor_pressure`](@ref), [`e_sat`](@ref), [`air_density`](@ref), [`psychrometer_constant`](@ref) or [`latent_heat_vaporization`](@ref)
-- easy download of weather data from renowned APIs such as [open-meteo.com](https://open-meteo.com/en) with [`OpenMeteo`](@ref)
-- and a framework to easily add more APIs thanks to [`get_weather`](@ref)
+`PlantMeteo` gives you a single workflow to standardize, inspect, and aggregate weather data into a structure that downstream plant models can use directly.
+
+## What You Get
+
+- A weather table abstraction with [`TimeStepTable`](@ref), [`Weather`](@ref), and [`Atmosphere`](@ref)
+- File ingestion and export with [`read_weather`](@ref) and [`write_weather`](@ref)
+- API retrieval through [`get_weather`](@ref) with the built-in [`OpenMeteo`](@ref) backend
+- A configurable sampler for model-aligned aggregation with [`prepare_weather_sampler`](@ref), [`sample_weather`](@ref), and [`materialize_weather`](@ref)
+
+## Who This Is For
+
+- model developers who need robust weather preprocessing before simulation
+- researchers combining historical files and forecast APIs
+- package authors who want to plug custom weather providers behind one interface
+
+## Documentation Map
+
+- Start with [Getting Started](getting-started.md)
+- Continue with in-depth guides:
+  - [Weather Data Sources](weather-apis.md)
+  - [Weather Sampling](weather-sampling.md)
+- Use [API](API.md) for full reference
 
 ## Installation
 
-To install the package, enter the Julia package manager mode by pressing `]` in the REPL, and execute the following command:
+From the Julia package REPL, run `add PlantMeteo`.
+Then load it with `using PlantMeteo`.
 
-```julia
-add PlantMeteo
-```
-
-To use the package, execute this command from the Julia REPL:
-
-```julia
-using PlantMeteo
-```
-
-## Projects that use PlantMeteo
-
-Take a look at these projects that use PlantSimEngine:
+## Projects Using PlantMeteo
 
 - [PlantSimEngine.jl](https://github.com/VEZY/PlantSimEngine.jl)
 - [PlantBiophysics.jl](https://github.com/VEZY/PlantBiophysics.jl)
 - [XPalm](https://github.com/PalmStudio/XPalm.jl)
-
-## Make it yours 
-
-The package is developed so anyone can easily integrate it into workflows and packages. For example [`TimeStepTable`](@ref) can be used for any type of data. See the implementation of `TimeStepTable{Status}` in [PlantSimEngine.jl](https://github.com/VEZY/PlantSimEngine.jl).
-
-If you develop such tools and it is not on the list yet, please make a PR or contact me so we can add it! 😃

--- a/docs/src/weather-apis.md
+++ b/docs/src/weather-apis.md
@@ -1,0 +1,126 @@
+```@meta
+CurrentModule = PlantMeteo
+```
+
+# Weather Data Sources
+
+This guide explains how PlantMeteo handles weather ingestion and export.
+
+## Design Intent
+
+The package separates concerns:
+
+- ingestion/parsing (`read_weather`, API backends)
+- canonical weather representation (`Weather`, `Atmosphere`)
+- optional conversion to sink formats (`DataFrame`, custom table sinks)
+
+This keeps model code independent of source-specific quirks.
+
+## Path 1: Local Files with `read_weather`
+
+Use this path when data comes from stations, archives, or partner pipelines.
+
+You can map source-specific column names and units to PlantMeteo variables, and get a standardized `Weather` table with parsed dates/durations and preserved metadata.
+
+```@example apis
+using PlantMeteo
+using Dates
+
+file = joinpath(dirname(dirname(pathof(PlantMeteo))), "test", "data", "meteo.csv")
+
+meteo = read_weather(
+    file,
+    :temperature => :T,
+    :relativeHumidity => (x -> x ./ 100) => :Rh,
+    :wind => :Wind,
+    :atmosphereCO2_ppm => :Cₐ,
+    date_format = DateFormat("yyyy/mm/dd")
+)
+
+(length(meteo), metadatakeys(meteo))
+```
+
+### Round-trip Export with `write_weather`
+
+Write a clean weather file for reuse, including metadata.
+
+For example we can verify the exported file reproduces the same records:
+
+```@example apis
+roundtrip_ok = mktempdir() do tmp
+    out = joinpath(tmp, "meteo_out.csv")
+    write_weather(out, meteo)
+    meteo2 = read_weather(out; duration = Dates.Minute)
+    length(meteo) == length(meteo2) && meteo2[1].T == meteo[1].T
+end
+
+roundtrip_ok
+```
+
+## Path 2: API Retrieval with `get_weather`
+
+Use this path when you don't have local data or need forecast/history for coordinates and dates.
+
+The default API uses Open-Meteo. You can control units, timezone, and model selection before requests, and get a configured API object you can reuse.
+
+```@example apis
+params = OpenMeteo(
+    units = OpenMeteoUnits(
+        temperature_unit = "celsius",
+        windspeed_unit = "ms",
+        precipitation_unit = "mm"
+    ),
+    timezone = "UTC",
+    models = ["best_match"]
+)
+
+(params.timezone, params.models, params.units.temperature_unit)
+```
+
+### Define Your Own API Via Our Interface
+
+Any type implementing `get_forecast` can be plugged into `get_weather`. For example, we can define a `DemoAPI` that returns a fixed weather series for any request:
+
+```@example apis
+struct DemoAPI <: PlantMeteo.AbstractAPI end
+
+function PlantMeteo.get_forecast(::DemoAPI, lat, lon, period; verbose=true, kwargs...)
+    hours = DateTime(period[1]):Hour(1):DateTime(period[end]) + Hour(23)
+    rows = Atmosphere[
+        Atmosphere(
+            date = t,
+            duration = Hour(1),
+            T = 20.0,
+            Wind = 1.0,
+            Rh = 0.6,
+            P = 101.3,
+            Ri_SW_f = 250.0
+        )
+        for t in hours
+    ]
+    TimeStepTable(rows, (latitude = lat, longitude = lon, source = "demo"))
+end
+
+period = Date(2025, 1, 1):Day(1):Date(2025, 1, 2)
+demo = get_weather(48.8566, 2.3522, period; api = DemoAPI())
+
+(length(demo), first(demo).date, last(demo).date)
+```
+
+### Switch the Output Sink
+
+You can use the `sink` keyword to get a different output format. For example, we can get a summary of the demo API output instead of the full weather table:
+
+```@example apis
+summary = get_weather(
+    48.8566,
+    2.3522,
+    period;
+    api = DemoAPI(),
+    sink = x -> (n = length(x), first_T = first(x.T), last_date = last(x.date))
+)
+
+summary
+```
+
+The sink argument can be any sink that implements the `Tables.jl` interface, like `DataFrame`. This allows you to integrate with downstream code that expects specific formats without changing the core API logic.

--- a/docs/src/weather-sampling.md
+++ b/docs/src/weather-sampling.md
@@ -1,0 +1,151 @@
+```@meta
+CurrentModule = PlantMeteo
+```
+
+# Weather Sampling
+
+This guide explains how to align raw weather time steps with model requirements.
+
+## Why Sampling?
+
+A model often needs weather at a different temporal scale than the source data.
+Examples:
+
+- source meteo is hourly, model step is 3 hours
+- source meteo is sub-hourly, model step is daily
+- a simulation needs both rolling and calendar-based aggregates
+
+The sampling API makes these choices explicit and testable.
+
+## Sampling Workflow
+
+1. define the source weather table
+2. prepare a sampler object (with optional caching)
+3. choose a window specification
+4. sample one step or materialize full sampled tables
+
+## 1. Create a Small, Predictable Weather Series
+
+For this example we'll use simple values so aggregation effects are easy to verify.
+We make 48 hourly rows (two days) with monotonic `T`:
+
+```@example sampling
+using PlantMeteo
+using Dates
+
+base = DateTime(2025, 1, 1)
+meteo = Weather([
+    Atmosphere(
+        date = base + Hour(i),
+        duration = Hour(1),
+        T = 10.0 + i,
+        Wind = 1.0,
+        Rh = 0.50 + 0.005 * i,
+        P = 100.0,
+        Ri_SW_f = 100.0 + 10.0 * i
+    )
+    for i in 0:47
+])
+
+meteo
+```
+
+## 2. Prepare Sampler State
+
+We can normalize transforms and enable query-level memoization with `prepare_weather_sampler`. This is optional but can speed up repeated calls with the same specs.
+This is done so that repeated identical calls can return cached objects (`lazy=true`).
+
+```@example sampling
+prepared = prepare_weather_sampler(meteo)  # lazy cache enabled by default
+typeof(prepared)
+```
+
+## 3. Rolling Window Sampling
+
+We can then aggregate over a trailing window in source-step units using `sample_weather`, which returns one aggregated `Atmosphere`.
+
+```@example sampling
+spec2 = MeteoSamplingSpec(2.0, 1.0)
+row3 = sample_weather(prepared, 3; spec = spec2)
+row3_cached = sample_weather(prepared, 3; spec = spec2)
+
+(row3.T, row3.Tmin, row3.Tmax, row3_cached === row3)
+```
+
+`sample_weather` provides default transforms for common variables (*i.e.* the ones in `Atmosphere`), but you can override them with custom rules (see next section).
+
+## 4. Override Variable-wise Aggregation Rules
+
+We can match aggregation logic to model semantics by overriding variable-wise aggregation rules. Custom transforms are normalized and applied for this call.
+
+```@example sampling
+custom = (
+    T = MeanWeighted(),
+    Tmax = (source = :T, reducer = MaxReducer()),
+    Tsum = (source = :T, reducer = SumReducer())
+)
+
+row_custom = sample_weather(prepared, 3; spec = spec2, transforms = custom)
+(row_custom.T, row_custom.Tmax, row_custom.Tsum)
+```
+
+## 5. Calendar Window Sampling
+
+Sometimes model logic is tied to civil periods (day/week/month) rather than fixed trailing windows. In this case, we can use `CalendarWindow` to aggregate all source steps that fall within the same period.
+This is useful for *e.g.* daily models that need to aggregate all hourly steps that fall within the same day, regardless of how many there are or where they fall in the source data. For example if you need the average temperature for the day, you can use a `CalendarWindow` anchored to the current period:
+
+```@example sampling
+spec_day = MeteoSamplingSpec(
+    1.0;
+    window = CalendarWindow(
+        :day;
+        anchor = :current_period,
+        week_start = 1,
+        completeness = :allow_partial
+    )
+)
+
+day_sample = sample_weather(prepared, 5; spec = spec_day)
+(day_sample.T, day_sample.Tmin, day_sample.Tmax, day_sample.duration)
+```
+
+We sample the fifth hour of the series, which falls on the first day. The sampled `T` is the average of the 24 hourly steps that fall within that day, which matches our expectation for a daily aggregation:
+
+```@example sampling
+mean(meteo[i].T for i in 1:24)
+```
+
+The result would be the same for any hour from 1 to 24, since they all fall in the same day:
+
+```@example sampling
+day_sample2 = sample_weather(prepared, 20; spec = spec_day)
+day_sample2.T == day_sample.T
+```
+
+The aggregated results are cached, so repeated calls with the same spec and query step will return the same values, and it means that performance will be ensured for long simulation loops with repeated calls:
+
+```@example sampling
+day_sample_cached = sample_weather(prepared, 6; spec = spec_day)
+day_sample_cached.T === day_sample.T
+```
+
+The returned `Atmosphere` is different though, since the date (and sometimes duration) are different for each query step, even if the aggregated values are the same:
+
+```@example sampling
+day_sample.date, day_sample_cached.date, day_sample2.date
+```
+
+Note that `CalendarWindow` expects a `date::DateTime` column in the weather. And with `completeness = :strict`, incomplete periods raise an error.
+
+## 6. Precompute for Simulation Loops
+
+When running long simulations, you can precompute all sampled weather tables upfront rather than sampling on-demand at each step. This trades a one-time preprocessing cost for faster lookups during the simulation loop. The `materialize_weather` function returns one sampled table per requested sampling spec, allowing efficient access throughout your simulation.
+
+```@example sampling
+specs = [spec2, spec_day]
+tables = materialize_weather(prepared; specs = specs)
+
+(length(tables), length(tables[spec2]), tables[spec2][3].T ≈ row3.T)
+```
+
+This is typically the best approach when you perform many simulations with the same weather, *e.g.* for model calibration, sensitivity analysis, or system optimization.

--- a/docs/src/weather-sampling.md
+++ b/docs/src/weather-sampling.md
@@ -32,6 +32,7 @@ We make 48 hourly rows (two days) with monotonic `T`:
 ```@example sampling
 using PlantMeteo
 using Dates
+using Statistics
 
 base = DateTime(2025, 1, 1)
 meteo = Weather([

--- a/src/PlantMeteo.jl
+++ b/src/PlantMeteo.jl
@@ -42,6 +42,7 @@ export get_weather
 export to_daily
 export AbstractTimeReducer
 export MeanWeighted, MeanReducer, SumReducer, MinReducer, MaxReducer, FirstReducer, LastReducer, RadiationEnergy
+export AbstractSamplingWindow, RollingWindow, CalendarWindow
 export MeteoSamplingSpec, MeteoTransform
 export PreparedWeather, prepare_weather_sampler, sample_weather, materialize_weather
 export default_sampling_transforms, normalize_sampling_transforms

--- a/src/PlantMeteo.jl
+++ b/src/PlantMeteo.jl
@@ -43,7 +43,7 @@ export to_daily
 export AbstractTimeReducer
 export MeanWeighted, MeanReducer, SumReducer, MinReducer, MaxReducer, FirstReducer, LastReducer, RadiationEnergy
 export AbstractSamplingWindow, RollingWindow, CalendarWindow
-export MeteoSamplingSpec, MeteoTransform
+export MeteoTransform
 export PreparedWeather, prepare_weather_sampler, sample_weather, materialize_weather
 export default_sampling_transforms, normalize_sampling_transforms
 

--- a/src/PlantMeteo.jl
+++ b/src/PlantMeteo.jl
@@ -24,8 +24,8 @@ include("APIs/open-meteo.jl")
 include("computations/conversions.jl")
 include("checks/check_day_complete.jl")
 include("computations/to_daily.jl")
+include("computations/weather_sampling.jl")
 include("APIs/write_weather.jl")
-# include("computations/weather_sampling.jl")
 
 export Atmosphere, TimeStepTable, Constants, Weather
 export get_index_raw
@@ -40,5 +40,10 @@ export get_forecast
 export OpenMeteo, OpenMeteoUnits
 export get_weather
 export to_daily
+export AbstractTimeReducer
+export MeanWeighted, MeanReducer, SumReducer, MinReducer, MaxReducer, FirstReducer, LastReducer, RadiationEnergy
+export MeteoSamplingSpec, MeteoTransform
+export PreparedWeather, prepare_weather_sampler, sample_weather, materialize_weather
+export default_sampling_transforms, normalize_sampling_transforms
 
 end

--- a/src/computations/weather_sampling.jl
+++ b/src/computations/weather_sampling.jl
@@ -170,7 +170,6 @@ MeteoTransform(target::Symbol; source::Symbol=target, reducer=MeanWeighted()) = 
 
 """
     PreparedWeather(weather; transforms=default_sampling_transforms(), lazy=true)
-    prepare_weather_sampler(weather; transforms=default_sampling_transforms(), lazy=true)
 
 Container holding a fine-step weather table and lazy sampling cache.
 """
@@ -193,6 +192,11 @@ function PreparedWeather(weather; transforms=default_sampling_transforms(), lazy
     )
 end
 
+"""
+    prepare_weather_sampler(weather; transforms=default_sampling_transforms(), lazy=true)
+
+Build the [`PreparedWeather`](@ref) container holding a fine-step weather table and lazy sampling cache.
+"""
 prepare_weather_sampler(weather; transforms=default_sampling_transforms(), lazy::Bool=true) =
     PreparedWeather(weather; transforms=transforms, lazy=lazy)
 
@@ -439,6 +443,21 @@ function _normalize_single_transform(target::Symbol, rule)
     return MeteoTransform(target; source=target, reducer=_normalize_reducer(rule))
 end
 
+"""
+    normalize_sampling_transforms(transforms)
+
+Normalize user-provided weather transform definitions into `Vector{MeteoTransform}`.
+
+Accepted inputs are:
+- `Vector{MeteoTransform}` (copied as-is)
+- `NamedTuple` where each key is the target variable and each value is either:
+  - a reducer (`AbstractTimeReducer` instance/type, or callable), or
+  - a named tuple with optional `source` and `reducer` fields
+- `AbstractVector` containing only `MeteoTransform` entries
+
+This is the canonical parser used by [`PreparedWeather`](@ref) and
+[`sample_weather`](@ref) to validate and materialize transform rules.
+"""
 function normalize_sampling_transforms(transforms::AbstractVector{MeteoTransform})
     return collect(transforms)
 end

--- a/src/computations/weather_sampling.jl
+++ b/src/computations/weather_sampling.jl
@@ -158,7 +158,7 @@ MeteoSamplingSpec(dt::Real; window::AbstractSamplingWindow=RollingWindow()) = Me
 """
     MeteoTransform(target; source=target, reducer=MeanWeighted())
 
-One weather transformation rule used by [`sample_weather`](@ref).
+One weather transformation rule used by [`PlantMeteo.sample_weather`](@ref).
 """
 struct MeteoTransform{R}
     target::Symbol
@@ -532,6 +532,29 @@ function _sample_weather_uncached(
     return Atmosphere(; check=false, kwargs...)
 end
 
+"""
+    sample_weather(prepared, step; spec=MeteoSamplingSpec(1.0, 0.0), transforms=nothing)
+
+Sample one aggregated weather row at `step` from a [`PreparedWeather`](@ref) sampler.
+
+# Arguments
+
+- `prepared::PreparedWeather`: output of [`prepare_weather_sampler`](@ref), holding source weather and optional cache.
+- `step::Int`: 1-based index in the original fine-step weather table.
+
+# Keyword arguments
+
+- `spec::MeteoSamplingSpec`: window definition and phase used to select rows before reduction.
+  The default `MeteoSamplingSpec(1.0, 0.0)` behaves as an identity window.
+- `transforms`: optional transform override for this call.
+  If `nothing`, uses `prepared.transforms`; otherwise accepted by
+  [`normalize_sampling_transforms`](@ref) (e.g. `NamedTuple` or `Vector{MeteoTransform}`).
+
+# Returns
+
+An `Atmosphere` instance built from reduced variables over the selected window.
+When `prepared.lazy == true`, results are memoized by `(step, spec, transforms)` and reused on repeated calls.
+"""
 function sample_weather(
     prepared::PreparedWeather,
     step::Int;

--- a/src/computations/weather_sampling.jl
+++ b/src/computations/weather_sampling.jl
@@ -1,0 +1,404 @@
+abstract type AbstractTimeReducer end
+
+"""
+    MeanWeighted()
+
+Duration-weighted mean reducer. When durations are not provided, falls back to a plain mean.
+"""
+struct MeanWeighted <: AbstractTimeReducer end
+
+"""
+    MeanReducer()
+
+Arithmetic mean reducer.
+"""
+struct MeanReducer <: AbstractTimeReducer end
+
+"""
+    SumReducer()
+
+Sum reducer.
+"""
+struct SumReducer <: AbstractTimeReducer end
+
+"""
+    MinReducer()
+
+Minimum reducer.
+"""
+struct MinReducer <: AbstractTimeReducer end
+
+"""
+    MaxReducer()
+
+Maximum reducer.
+"""
+struct MaxReducer <: AbstractTimeReducer end
+
+"""
+    FirstReducer()
+
+Reducer returning first value in the window.
+"""
+struct FirstReducer <: AbstractTimeReducer end
+
+"""
+    LastReducer()
+
+Reducer returning last value in the window.
+"""
+struct LastReducer <: AbstractTimeReducer end
+
+"""
+    RadiationEnergy()
+
+Integrate flux values (W m-2) over durations (seconds) into MJ m-2.
+"""
+struct RadiationEnergy <: AbstractTimeReducer end
+
+(::MeanWeighted)(vals::AbstractVector{<:Real}) = Statistics.mean(vals)
+function (::MeanWeighted)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real})
+    num = 0.0
+    den = 0.0
+    for (v, d) in zip(vals, durations)
+        num += float(v) * float(d)
+        den += float(d)
+    end
+    den == 0.0 && return nothing
+    return num / den
+end
+
+(::MeanReducer)(vals::AbstractVector{<:Real}) = Statistics.mean(vals)
+(::MeanReducer)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real}) = Statistics.mean(vals)
+
+(::SumReducer)(vals::AbstractVector{<:Real}) = sum(vals)
+(::SumReducer)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real}) = sum(vals)
+
+(::MinReducer)(vals::AbstractVector{<:Real}) = minimum(vals)
+(::MinReducer)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real}) = minimum(vals)
+
+(::MaxReducer)(vals::AbstractVector{<:Real}) = maximum(vals)
+(::MaxReducer)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real}) = maximum(vals)
+
+(::FirstReducer)(vals::AbstractVector) = first(vals)
+(::FirstReducer)(vals::AbstractVector, durations::AbstractVector{<:Real}) = first(vals)
+
+(::LastReducer)(vals::AbstractVector) = last(vals)
+(::LastReducer)(vals::AbstractVector, durations::AbstractVector{<:Real}) = last(vals)
+
+function (::RadiationEnergy)(vals::AbstractVector{<:Real}, durations::AbstractVector{<:Real})
+    # W m-2 integrated over seconds -> MJ m-2
+    return sum(float(v) * float(d) for (v, d) in zip(vals, durations)) * 1.0e-6
+end
+
+function (::RadiationEnergy)(vals::AbstractVector{<:Real})
+    error("`RadiationEnergy` requires durations. Use it only in weather sampling contexts.")
+end
+
+"""
+    MeteoSamplingSpec(dt, phase=0.0)
+
+Sampling specification used to aggregate fine-step weather into a model clock window.
+`dt` and `phase` are expressed in base weather timesteps.
+"""
+struct MeteoSamplingSpec{T<:Real}
+    dt::T
+    phase::T
+end
+
+MeteoSamplingSpec(dt::T) where {T<:Real} = MeteoSamplingSpec{T}(dt, zero(T))
+
+"""
+    MeteoTransform(target; source=target, reducer=MeanWeighted())
+
+One weather transformation rule used by [`sample_weather`](@ref).
+"""
+struct MeteoTransform{R}
+    target::Symbol
+    source::Symbol
+    reducer::R
+end
+
+MeteoTransform(target::Symbol; source::Symbol=target, reducer=MeanWeighted()) = MeteoTransform(target, source, reducer)
+
+"""
+    PreparedWeather(weather; transforms=default_sampling_transforms(), lazy=true)
+    prepare_weather_sampler(weather; transforms=default_sampling_transforms(), lazy=true)
+
+Container holding a fine-step weather table and lazy sampling cache.
+"""
+mutable struct PreparedWeather{W,T,C}
+    weather::W
+    transforms::T
+    cache::C
+    lazy::Bool
+end
+
+function PreparedWeather(weather; transforms=default_sampling_transforms(), lazy::Bool=true)
+    normalized = normalize_sampling_transforms(transforms)
+    PreparedWeather(
+        weather,
+        normalized,
+        Dict{Tuple{Int,UInt64,UInt64},Any}(),
+        lazy
+    )
+end
+
+prepare_weather_sampler(weather; transforms=default_sampling_transforms(), lazy::Bool=true) =
+    PreparedWeather(weather; transforms=transforms, lazy=lazy)
+
+function _duration_seconds(d)
+    if d isa Dates.Period
+        return float(Dates.toms(d)) * 1.0e-3
+    elseif d isa Real
+        return float(d)
+    end
+    return 1.0
+end
+
+function _duration_period_from_seconds(sec::Float64)
+    ms = round(Int, sec * 1000.0)
+    return Dates.Millisecond(ms)
+end
+
+function _window_bounds(step::Int, spec::MeteoSamplingSpec)
+    dt = float(spec.dt)
+    dt <= 1.0 && return step, step
+    start = Int(floor(step - dt + 1.0 + 1.0e-8))
+    return max(1, start), step
+end
+
+function _transform_signature(transforms::AbstractVector{MeteoTransform})
+    h = hash(length(transforms))
+    for t in transforms
+        h = hash((h, t.target, t.source, t.reducer))
+    end
+    return UInt64(h)
+end
+
+function _default_radiation_flux_vars()
+    (
+        :Ri_SW_f,
+        :Ri_PAR_f,
+        :Ri_NIR_f,
+        :Ri_TIR_f,
+        :Ri_custom_f,
+    )
+end
+
+"""
+    default_sampling_transforms(; radiation_mode=:both)
+
+Default weather sampling rules.
+
+`radiation_mode` controls how radiation targets are emitted:
+- `:flux_mean`: duration-weighted mean flux (same units as source)
+- `:energy_sum`: integrated quantity in MJ m-2 over the sampling window
+- `:both`: keep `Ri_*_f` as weighted-mean flux and also emit `Ri_*_q` quantities
+"""
+function default_sampling_transforms(; radiation_mode::Symbol=:both)
+    radiation_mode in (:flux_mean, :energy_sum, :both) || error(
+        "Unsupported radiation_mode `$(radiation_mode)`. Allowed values are :flux_mean, :energy_sum, :both."
+    )
+
+    transforms = MeteoTransform[
+        MeteoTransform(:T; reducer=MeanWeighted()),
+        MeteoTransform(:Tmin; source=:T, reducer=MinReducer()),
+        MeteoTransform(:Tmax; source=:T, reducer=MaxReducer()),
+        MeteoTransform(:Wind; reducer=MeanWeighted()),
+        MeteoTransform(:P; reducer=MeanWeighted()),
+        MeteoTransform(:Rh; reducer=MeanWeighted()),
+        MeteoTransform(:Rhmin; source=:Rh, reducer=MinReducer()),
+        MeteoTransform(:Rhmax; source=:Rh, reducer=MaxReducer()),
+        MeteoTransform(:Precipitations; reducer=SumReducer()),
+        MeteoTransform(:Cₐ; reducer=MeanWeighted()),
+        MeteoTransform(:e; reducer=MeanWeighted()),
+        MeteoTransform(:eₛ; reducer=MeanWeighted()),
+        MeteoTransform(:VPD; reducer=MeanWeighted()),
+        MeteoTransform(:ρ; reducer=MeanWeighted()),
+        MeteoTransform(:λ; reducer=MeanWeighted()),
+        MeteoTransform(:γ; reducer=MeanWeighted()),
+        MeteoTransform(:ε; reducer=MeanWeighted()),
+        MeteoTransform(:Δ; reducer=MeanWeighted()),
+        MeteoTransform(:clearness; reducer=MeanWeighted()),
+    ]
+
+    for var in _default_radiation_flux_vars()
+        if radiation_mode == :energy_sum
+            push!(transforms, MeteoTransform(var; source=var, reducer=RadiationEnergy()))
+        else
+            push!(transforms, MeteoTransform(var; source=var, reducer=MeanWeighted()))
+        end
+    end
+
+    if radiation_mode == :both
+        for var in _default_radiation_flux_vars()
+            q = Symbol(replace(String(var), "_f" => "_q"))
+            push!(transforms, MeteoTransform(q; source=var, reducer=RadiationEnergy()))
+        end
+    end
+
+    return transforms
+end
+
+function _normalize_reducer(reducer)
+    if reducer isa DataType
+        reducer <: AbstractTimeReducer || error(
+            "Unsupported reducer type `$(reducer)`. ",
+            "Expected a subtype of `AbstractTimeReducer` or a callable."
+        )
+        return reducer()
+    elseif reducer isa AbstractTimeReducer
+        return reducer
+    elseif reducer isa Function
+        return reducer
+    end
+
+    error(
+        "Unsupported reducer value `$(reducer)` of type `$(typeof(reducer))`. ",
+        "Use a reducer instance/type (subtype of `AbstractTimeReducer`) or a callable."
+    )
+end
+
+function _normalize_single_transform(target::Symbol, rule)
+    if rule isa NamedTuple
+        src = haskey(rule, :source) ? Symbol(rule.source) : target
+        reducer = haskey(rule, :reducer) ? _normalize_reducer(rule.reducer) : MeanWeighted()
+        return MeteoTransform(target; source=src, reducer=reducer)
+    end
+
+    return MeteoTransform(target; source=target, reducer=_normalize_reducer(rule))
+end
+
+function normalize_sampling_transforms(transforms::AbstractVector{MeteoTransform})
+    return collect(transforms)
+end
+
+function normalize_sampling_transforms(transforms::NamedTuple)
+    out = MeteoTransform[]
+    for (target, rule) in pairs(transforms)
+        push!(out, _normalize_single_transform(Symbol(target), rule))
+    end
+    return out
+end
+
+function normalize_sampling_transforms(transforms::AbstractVector)
+    out = MeteoTransform[]
+    for t in transforms
+        if t isa MeteoTransform
+            push!(out, t)
+        else
+            error("Unsupported transform element type `$(typeof(t))`.")
+        end
+    end
+    return out
+end
+
+function _reduce_values(vals::AbstractVector, durations::AbstractVector{<:Real}, reducer)
+    isempty(vals) && return nothing
+    if reducer isa AbstractTimeReducer
+        if reducer isa Union{FirstReducer,LastReducer}
+            return reducer(vals, durations)
+        end
+        all(v -> v isa Real, vals) || return nothing
+        vals_real = float.(vals)
+        if applicable(reducer, vals_real, durations)
+            return reducer(vals_real, durations)
+        elseif applicable(reducer, vals_real)
+            return reducer(vals_real)
+        end
+    else
+        if applicable(reducer, vals, durations)
+            return reducer(vals, durations)
+        elseif applicable(reducer, vals)
+            return reducer(vals)
+        end
+    end
+
+    error("Reducer `$(reducer)` is not callable on sampled weather values.")
+end
+
+function _sample_weather_uncached(
+    weather::TimeStepTable,
+    step::Int,
+    spec::MeteoSamplingSpec,
+    transforms::AbstractVector{MeteoTransform}
+)
+    1 <= step <= length(weather) || error("Invalid weather step $(step), expected 1 <= step <= $(length(weather)).")
+    start, stop = _window_bounds(step, spec)
+
+    rows = [weather[i] for i in start:stop]
+    current = weather[step]
+    durations = [
+        hasproperty(r, :duration) ? _duration_seconds(getproperty(r, :duration)) : 1.0
+        for r in rows
+    ]
+
+    sampled = Dict{Symbol,Any}()
+    for tr in transforms
+        vals = Any[]
+        durs = Float64[]
+        for (r, d) in zip(rows, durations)
+            hasproperty(r, tr.source) || continue
+            push!(vals, getproperty(r, tr.source))
+            push!(durs, d)
+        end
+        isempty(vals) && continue
+        v = _reduce_values(vals, durs, tr.reducer)
+        isnothing(v) && continue
+        sampled[tr.target] = v
+    end
+
+    sampled[:date] = hasproperty(current, :date) ? getproperty(current, :date) : Dates.now()
+    sampled[:duration] = _duration_period_from_seconds(sum(durations))
+
+    # Required core variables for Atmosphere
+    sampled[:T] = get(sampled, :T, hasproperty(current, :T) ? getproperty(current, :T) : error("Missing required meteo variable :T"))
+    sampled[:Wind] = get(sampled, :Wind, hasproperty(current, :Wind) ? getproperty(current, :Wind) : error("Missing required meteo variable :Wind"))
+    sampled[:Rh] = get(sampled, :Rh, hasproperty(current, :Rh) ? getproperty(current, :Rh) : error("Missing required meteo variable :Rh"))
+    sampled[:P] = get(sampled, :P, hasproperty(current, :P) ? getproperty(current, :P) : DEFAULTS.P)
+
+    keys_sorted = sort!(collect(keys(sampled)))
+    kwargs = (; (k => sampled[k] for k in keys_sorted)...)
+    return Atmosphere(; check=false, kwargs...)
+end
+
+function sample_weather(
+    prepared::PreparedWeather,
+    step::Int;
+    spec::MeteoSamplingSpec=MeteoSamplingSpec(1.0, 0.0),
+    transforms=nothing
+)
+    rules = isnothing(transforms) ? prepared.transforms : normalize_sampling_transforms(transforms)
+    spec_sig = UInt64(hash((float(spec.dt), float(spec.phase))))
+    tr_sig = _transform_signature(rules)
+    key = (step, spec_sig, tr_sig)
+
+    if prepared.lazy && haskey(prepared.cache, key)
+        return prepared.cache[key]
+    end
+
+    sampled = _sample_weather_uncached(prepared.weather, step, spec, rules)
+    if prepared.lazy
+        prepared.cache[key] = sampled
+    end
+    return sampled
+end
+
+"""
+    materialize_weather(prepared; specs, transforms=nothing)
+
+Precompute sampled weather tables for a set of sampling specs.
+Returns `Dict{MeteoSamplingSpec,TimeStepTable{Atmosphere}}`.
+"""
+function materialize_weather(prepared::PreparedWeather; specs, transforms=nothing)
+    tables = Dict{MeteoSamplingSpec,TimeStepTable{Atmosphere}}()
+    for spec in specs
+        rows = Atmosphere[
+            sample_weather(prepared, i; spec=spec, transforms=transforms)
+            for i in 1:length(prepared.weather)
+        ]
+        tables[spec] = TimeStepTable(rows, metadata(prepared.weather))
+    end
+    return tables
+end

--- a/src/computations/weather_sampling.jl
+++ b/src/computations/weather_sampling.jl
@@ -274,7 +274,7 @@ function CalendarWindow(
     period::Symbol;
     anchor::Symbol=:current_period,
     week_start::Int=1,
-    completeness::Symbol=:stict
+    completeness::Symbol=:strict
 )
     period in (:day, :week, :month) || error(
         "Unsupported calendar period `$(period)`. Allowed values are :day, :week, :month."

--- a/src/computations/weather_sampling.jl
+++ b/src/computations/weather_sampling.jl
@@ -86,8 +86,8 @@ function (::MeanWeighted)(vals::AbstractVector{<:Real}, durations::AbstractVecto
     num = 0.0
     den = 0.0
     for (v, d) in zip(vals, durations)
-        num += float(v) * float(d)
-        den += float(d)
+        num += v * d
+        den += d
     end
     den == 0.0 && return nothing
     return num / den
@@ -304,7 +304,7 @@ Build a typed sampling spec for [`sample_weather`](@ref).
   or [`CalendarWindow`](@ref).
 """
 function MeteoSamplingSpec(dt::Real, phase::Real; window::AbstractSamplingWindow=RollingWindow())
-    T = promote_type(typeof(float(dt)), typeof(float(phase)))
+    T = promote_type(typeof(dt), typeof(phase))
     return MeteoSamplingSpec{T,typeof(window)}(T(dt), T(phase), window)
 end
 
@@ -403,9 +403,9 @@ Convert a duration-like value to seconds.
 """
 function _duration_seconds(d)
     if d isa Dates.Period
-        return float(Dates.toms(d)) * 1.0e-3
+        return Dates.toms(d) * 1.0e-3
     elseif d isa Real
-        return float(d)
+        return d
     end
     return 1.0
 end
@@ -435,7 +435,7 @@ Compute inclusive trailing bounds `(start, stop)` for a [`RollingWindow`](@ref).
 - `spec::MeteoSamplingSpec`: sampling spec containing `dt`.
 """
 function _window_bounds(step::Int, spec::MeteoSamplingSpec)
-    dt = float(spec.dt)
+    dt = spec.dt
     dt <= 1.0 && return step, step
     start = Int(floor(step - dt + 1.0 + 1.0e-8))
     return max(1, start), step
@@ -494,7 +494,7 @@ function _expected_period_seconds(period_key::Dates.Date, window::CalendarWindow
     elseif window.period == :week
         return 7.0 * 86400.0
     elseif window.period == :month
-        return float(Dates.daysinmonth(period_key)) * 86400.0
+        return Dates.daysinmonth(period_key) * 86400.0
     end
     error("Unsupported calendar period `$(window.period)`.")
 end
@@ -944,7 +944,7 @@ function sample_weather(
     transforms=nothing
 )
     rules = isnothing(transforms) ? prepared.transforms : normalize_sampling_transforms(transforms)
-    spec_sig = UInt64(hash((float(spec.dt), float(spec.phase), spec.window)))
+    spec_sig = UInt64(hash((spec.dt, spec.phase, spec.window)))
     tr_sig = _transform_signature(rules)
     key = (step, spec_sig, tr_sig)
 

--- a/src/structs/TimeStepTable.jl
+++ b/src/structs/TimeStepTable.jl
@@ -148,7 +148,7 @@ end
 
 ###### Tables.jl interface ######
 
-Tables.istable(::Type{TimeStepTable}) = true
+Tables.istable(::Type{TimeStepTable{T}}) where {T} = true
 
 # Keys should be the same between TimeStepTable so we only need the ones from the first timestep
 Base.keys(ts::TimeStepTable) = getfield(ts, :names)

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.3"
+julia_version = "1.12.1"
 manifest_format = "2.0"
-project_hash = "607a34e33a0a7127e5b28b892f72a3f7a1826824"
+project_hash = "e3970b4719790fa083b243d7be7a528bb440f0ea"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -16,25 +16,27 @@ version = "0.4.5"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.6"
+version = "0.7.8"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.16.0"
+version = "4.18.1"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -43,7 +45,7 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.0+1"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -57,15 +59,15 @@ version = "1.16.0"
 
 [[deps.DataFrames]]
 deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "fb61b4812c49343d7ef0b533ba982c46021938a6"
+git-tree-sha1 = "d8928e9169ff76c6281f39a659f9bca3a573f24c"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.7.0"
+version = "1.8.1"
 
 [[deps.DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
+deps = ["OrderedCollections"]
+git-tree-sha1 = "e357641bb3e0638d353c4b29ea0e40ea644066a6"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.20"
+version = "0.19.3"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -75,18 +77,18 @@ version = "1.0.0"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+version = "0.9.5"
 
 [[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "d0ea2c044963ed6f37703cead7e29f70cba13d7e"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "b37458ae37d8bdb643d763451585cd8d0e5b4a9e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.8.0"
+version = "1.16.1"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -95,39 +97,47 @@ version = "1.6.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "cc5231d52eb1771251fbd37171dbc408bcc8a1b6"
+git-tree-sha1 = "27af30de8b5445644e8ffe3bcb0d72049c089cf1"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.4+0"
+version = "2.7.3+0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
 
 [[deps.Git]]
-deps = ["Git_jll"]
-git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.1"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "bb8471f313ed941f299aa53d32a94ab3bee08844"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.0+0"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
+git-tree-sha1 = "dc34a3e3d96b4ed305b641e626dc14c12b7824b8"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.46.2+0"
+version = "2.53.0+0"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "b6d6bfdd7ce25b0f9b2f6b3dd56b2673a66c8770"
+git-tree-sha1 = "0ee181ec08df7d7c911901ea38baf16f755114dc"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.5"
+version = "1.0.0"
 
 [[deps.InlineStrings]]
-git-tree-sha1 = "45521d31238e87ee9f9732561bfee12d4eebd52d"
+git-tree-sha1 = "8f3d257792a522b4601c24a577954b0a8cd7334d"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.4.2"
+version = "1.4.5"
 
     [deps.InlineStrings.extensions]
     ArrowTypesExt = "ArrowTypes"
@@ -140,11 +150,12 @@ version = "1.4.2"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.InvertedIndices]]
-git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
+git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -153,15 +164,26 @@ version = "1.0.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.6.1"
+version = "1.7.1"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "b3ad4a0255688dcb895a52fafbaae3023b588a90"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.4.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
@@ -179,43 +201,48 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.11.1+1"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "61dfdba58e585066d8bce214c5a51eaa0539f269"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+1"
+version = "1.18.0+0"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MarkdownAST]]
 deps = ["AbstractTrees", "Markdown"]
@@ -223,59 +250,60 @@ git-tree-sha1 = "465a70f0fc7d443a00dcdc3267a497397b8a3899"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 version = "0.1.2"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
-
 [[deps.Missings]]
 deps = ["DataAPI"]
 git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 version = "1.2.0"
 
-[[deps.Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.5.20"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.29+0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "301412a644646fdc0ad67d0a87487466b491e53d"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.2.1+0"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+1"
+version = "3.5.1+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.3"
+version = "1.8.1"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.1"
+version = "2.8.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.12.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
 
 [[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
@@ -285,33 +313,36 @@ version = "1.4.3"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.1"
+version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+git-tree-sha1 = "522f093a29b31a93e34eaea17ba055d850edea28"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.3"
+version = "1.5.1"
 
 [[deps.PrettyTables]]
-deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "c5a07210bd060d6a8491b0ccdee2fa0235fc00bf"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "2.4.0"
+version = "3.1.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -330,42 +361,59 @@ version = "0.7.0"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
-git-tree-sha1 = "d0553ce4031a081cc42387a9b9c8441b7d99f32d"
+git-tree-sha1 = "ebe7e59b37c400f694f52b58c93d26201387da70"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.4.7"
+version = "1.4.9"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "66e0a8e672a0bdfca2c3f5937efb8538b9ddc085"
+git-tree-sha1 = "64d974c2e6fdf07f8155b5b2ca2ffa9069b608d9"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.2.1"
-
-[[deps.SparseArrays]]
-deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.10.0"
+version = "1.2.2"
 
 [[deps.Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.10.0"
+version = "1.11.1"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "a6b1675a536c5ad1a60e5a5153e1fee12eb146e3"
+git-tree-sha1 = "a3c1536470bf8c5e02096ad4853606d7c8f62721"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.0"
+version = "0.4.2"
 
-[[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
-uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.2.1+1"
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "9297459be9e338e546f5c4bedb59b3b5674da7f1"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.6.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -380,9 +428,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
-git-tree-sha1 = "598cd7c1f68d1e205689b1c2fe65a9f85846f297"
+git-tree-sha1 = "f2c1efbc8f3a609aadf318094f8fc5204bdaf344"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.12.0"
+version = "1.12.1"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -392,6 +440,7 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -401,26 +450,28 @@ version = "0.11.3"
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+1"
+version = "5.15.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.5.0+2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,10 @@ using Documenter # for doctests
         include("test-to_daily.jl")
     end
 
+    @testset "weather sampling" begin
+        include("test-weather_sampling.jl")
+    end
+
     @testset "Doctests" begin
         DocMeta.setdocmeta!(PlantMeteo, :DocTestSetup, :(using PlantMeteo, Dates); recursive=true)
 

--- a/test/test-weather_sampling.jl
+++ b/test/test-weather_sampling.jl
@@ -78,7 +78,7 @@ end
         Atmosphere(
             date=base + Dates.Hour(i - 1),
             duration=Dates.Hour(1),
-            T=float(i),
+            T=i,
             Wind=1.0,
             Rh=0.50,
             P=100.0,
@@ -90,7 +90,7 @@ end
         Atmosphere(
             date=base + Dates.Hour(24 + i - 1),
             duration=Dates.Hour(1),
-            T=float(100 + i),
+            T=100 + i,
             Wind=1.0,
             Rh=0.60,
             P=100.0,

--- a/test/test-weather_sampling.jl
+++ b/test/test-weather_sampling.jl
@@ -1,0 +1,72 @@
+using Test
+using Dates
+
+@testset "weather sampling" begin
+    base_date = Dates.DateTime(2025, 1, 1, 0, 0, 0)
+    meteo = Weather([
+        Atmosphere(date=base_date + Dates.Hour(0), duration=Dates.Hour(1), T=10.0, Wind=1.0, Rh=0.50, P=100.0, Ri_SW_f=100.0, custom_var=1.0),
+        Atmosphere(date=base_date + Dates.Hour(1), duration=Dates.Hour(1), T=20.0, Wind=1.0, Rh=0.60, P=100.0, Ri_SW_f=200.0, custom_var=2.0),
+        Atmosphere(date=base_date + Dates.Hour(2), duration=Dates.Hour(1), T=30.0, Wind=1.0, Rh=0.70, P=100.0, Ri_SW_f=300.0, custom_var=3.0),
+        Atmosphere(date=base_date + Dates.Hour(3), duration=Dates.Hour(1), T=40.0, Wind=1.0, Rh=0.80, P=100.0, Ri_SW_f=400.0, custom_var=4.0),
+    ])
+
+    prepared = prepare_weather_sampler(meteo)
+    spec2 = MeteoSamplingSpec(2.0, 1.0)
+
+    s1 = sample_weather(prepared, 1; spec=spec2)
+    @test s1.T == 10.0
+    @test s1.Tmin == 10.0
+    @test s1.Tmax == 10.0
+    @test s1.Rh == 0.5
+    @test s1.Ri_SW_f == 100.0
+    @test isapprox(s1.Ri_SW_q, 0.36; atol=1.0e-9)
+
+    s3 = sample_weather(prepared, 3; spec=spec2)
+    @test s3.T == 25.0
+    @test s3.Tmin == 20.0
+    @test s3.Tmax == 30.0
+    @test s3.Rh == 0.65
+    @test s3.Rhmin == 0.6
+    @test s3.Rhmax == 0.7
+    @test s3.Ri_SW_f == 250.0
+    @test isapprox(s3.Ri_SW_q, 1.8; atol=1.0e-9)
+    @test s3.duration == Dates.Hour(2)
+
+    # Lazy cache should return the same object for the same query.
+    s3_cached = sample_weather(prepared, 3; spec=spec2)
+    @test s3_cached === s3
+
+    # Custom transform override with radiation quantity on Ri_SW_f itself.
+    custom = (
+        Ri_SW_f=(source=:Ri_SW_f, reducer=RadiationEnergy()),
+        custom_peak=(source=:custom_var, reducer=MaxReducer()),
+    )
+    s3_custom = sample_weather(prepared, 3; spec=spec2, transforms=custom)
+    @test isapprox(s3_custom.Ri_SW_f, 1.8; atol=1.0e-9)
+    @test s3_custom.custom_peak == 3.0
+
+    # Precompute path for repeated simulations.
+    tables = materialize_weather(prepared; specs=[spec2])
+    @test haskey(tables, spec2)
+    @test length(tables[spec2]) == length(meteo)
+    @test tables[spec2][3].T == s3.T
+
+    # Default transform mode switching: radiation in quantity on *_f targets.
+    prepared_energy = prepare_weather_sampler(meteo; transforms=default_sampling_transforms(radiation_mode=:energy_sum))
+    s3_energy = sample_weather(prepared_energy, 3; spec=spec2)
+    @test isapprox(s3_energy.Ri_SW_f, 1.8; atol=1.0e-9)
+
+    # Reducer types can be provided directly (without symbols).
+    typed = (
+        T=MeanWeighted(),
+        Tmax=(source=:T, reducer=MaxReducer()),
+        Tsum=(source=:T, reducer=SumReducer()),
+    )
+    s3_typed = sample_weather(prepared, 3; spec=spec2, transforms=typed)
+    @test s3_typed.T == 25.0
+    @test s3_typed.Tmax == 30.0
+    @test s3_typed.Tsum == 50.0
+
+    # Symbol reducers are intentionally unsupported in the new API.
+    @test_throws "Unsupported reducer value" sample_weather(prepared, 3; spec=spec2, transforms=(; T=:weighted_mean))
+end


### PR DESCRIPTION
Introducing a weather sampling feature to the `PlantMeteo.jl` package, including new functionality for sampling and transforming weather data:

* Added `computations/weather_sampling.jl` to the main module, enabling weather sampling functionality.
* Exported new types and functions related to weather sampling, including `AbstractTimeReducer`, various reducer types, `MeteoSamplingSpec`, `MeteoTransform`, and sampling functions like `prepare_weather_sampler`, `sample_weather`, and `materialize_weather`.