### PR TITLE
Add new features to make PlantMeteo compatible with archimed:

### DIFF
--- a/src/PlantMeteo.jl
+++ b/src/PlantMeteo.jl
@@ -23,6 +23,7 @@ include("APIs/read_weather.jl")
 include("APIs/open-meteo.jl")
 include("computations/conversions.jl")
 include("checks/check_day_complete.jl")
+include("checks/timestep_intervals.jl")
 include("computations/to_daily.jl")
 include("computations/weather_sampling.jl")
 include("APIs/write_weather.jl")
@@ -36,6 +37,8 @@ export psychrometer_constant
 export rh_from_vpd, rh_from_e, vpd, vpd_from_e
 export metadata, metadatakeys
 export read_weather, write_weather
+export duration_seconds, positive_duration_seconds
+export row_datetime_interval, check_non_overlapping_timesteps, select_overlapping_timesteps
 export get_forecast
 export OpenMeteo, OpenMeteoUnits
 export get_weather

--- a/src/checks/timestep_intervals.jl
+++ b/src/checks/timestep_intervals.jl
@@ -1,0 +1,216 @@
+"""
+    duration_seconds(x; field_name="duration", allow_nan=true)
+
+Convert a duration-like value into seconds.
+
+Accepted values are:
+- numeric values (already in seconds),
+- `Dates.Period`,
+- `Dates.Time`,
+- `Dates.DateTime`,
+- strings formatted as `HH:MM[:SS]`,
+- strings parseable as numbers.
+
+When parsing fails, the function returns `NaN` if `allow_nan=true`, otherwise it throws.
+"""
+function duration_seconds(x; field_name::AbstractString="duration", allow_nan::Bool=true)
+    x === missing && return allow_nan ? NaN : error("Invalid $(field_name) value: missing")
+
+    if x isa Number
+        return Float64(x)
+    elseif x isa Dates.Time
+        return Float64(Dates.hour(x) * 3600 + Dates.minute(x) * 60 + Dates.second(x))
+    elseif x isa Dates.DateTime
+        t = Dates.Time(x)
+        return Float64(Dates.hour(t) * 3600 + Dates.minute(t) * 60 + Dates.second(t))
+    elseif x isa Dates.Period
+        return Dates.toms(x) * 1.0e-3
+    end
+
+    s = strip(string(x))
+    if isempty(s) || lowercase(s) in ("na", "nan", "missing")
+        return allow_nan ? NaN : error("Invalid $(field_name) value: $(repr(x))")
+    end
+
+    for fmt in (Dates.DateFormat("HH:MM:SS"), Dates.DateFormat("HH:MM"))
+        try
+            t = Dates.Time(s, fmt)
+            return Float64(Dates.hour(t) * 3600 + Dates.minute(t) * 60 + Dates.second(t))
+        catch
+        end
+    end
+
+    n = tryparse(Float64, s)
+    if n === nothing
+        return allow_nan ? NaN : error("Invalid $(field_name) value: $(repr(x))")
+    end
+    return n
+end
+
+"""
+    positive_duration_seconds(x; field_name="duration")
+
+Convert a duration-like value to seconds and ensure it is finite and strictly positive.
+"""
+function positive_duration_seconds(x; field_name::AbstractString="duration")
+    seconds = duration_seconds(x; field_name=field_name, allow_nan=false)
+    if !(isfinite(seconds) && seconds > 0.0)
+        error("Invalid $(field_name) value: expected a positive duration, got $(repr(x))")
+    end
+    return seconds
+end
+
+function _parse_time_strict(v, field_name::String)
+    v === missing && error("invalid value: missing $(field_name)")
+    if v isa Dates.Time
+        return v
+    elseif v isa Dates.DateTime
+        return Dates.Time(v)
+    end
+    s = strip(string(v))
+    isempty(s) && error("invalid value: empty $(field_name)")
+    for fmt in (Dates.DateFormat("HH:MM:SS"), Dates.DateFormat("HH:MM"), Dates.DateFormat("H:MM:SS"), Dates.DateFormat("H:MM"))
+        try
+            return Dates.Time(s, fmt)
+        catch
+        end
+    end
+    error("invalid value: cannot parse $(field_name)=$(repr(v))")
+end
+
+function _parse_date_or_default(v, default::Dates.Date)
+    v === missing && return default
+    if v isa Dates.Date
+        return v
+    elseif v isa Dates.DateTime
+        return Dates.Date(v)
+    end
+    s = strip(string(v))
+    (isempty(s) || lowercase(s) == "missing") && return default
+    for fmt in (
+        Dates.DateFormat("yyyy/mm/dd"),
+        Dates.DateFormat("yyyy-mm-dd"),
+        Dates.DateFormat("yyyy/mm/ddTHH:MM:SS"),
+        Dates.DateFormat("yyyy-mm-ddTHH:MM:SS"),
+    )
+        try
+            return Dates.Date(s, fmt)
+        catch
+        end
+    end
+    return default
+end
+
+function _first_present_column(row, cols::Tuple{Vararg{Symbol}})
+    names = propertynames(row)
+    for c in cols
+        c in names && return c
+    end
+    return nothing
+end
+
+"""
+    row_datetime_interval(
+        row;
+        index=0,
+        date_cols=(:date,),
+        start_cols=(:hour_start, :hour),
+        end_cols=(:hour_end,),
+        duration_cols=(:step_duration, :duration),
+        default_date=Date(2000, 1, 1),
+        default_duration_seconds=1.0,
+        allow_end_rollover=false,
+    )
+
+Return `(start_dt, end_dt)` for one timestep row.
+
+`start_dt` is built from `date_cols` + `start_cols`. `end_dt` is taken from `end_cols`,
+or derived from `duration_cols`, or from `default_duration_seconds` when no explicit end
+is available.
+"""
+function row_datetime_interval(
+    row;
+    index::Int=0,
+    date_cols::Tuple{Vararg{Symbol}}=(:date,),
+    start_cols::Tuple{Vararg{Symbol}}=(:hour_start, :hour),
+    end_cols::Tuple{Vararg{Symbol}}=(:hour_end,),
+    duration_cols::Tuple{Vararg{Symbol}}=(:step_duration, :duration),
+    default_date::Dates.Date=Dates.Date(2000, 1, 1),
+    default_duration_seconds::Float64=1.0,
+    allow_end_rollover::Bool=false,
+)
+    start_col = _first_present_column(row, start_cols)
+    start_col === nothing && error("invalid value: missing start column at row $(index)")
+
+    date_col = _first_present_column(row, date_cols)
+    date = date_col === nothing ? default_date : _parse_date_or_default(getproperty(row, date_col), default_date)
+
+    start_time = _parse_time_strict(getproperty(row, start_col), String(start_col))
+    start_dt = Dates.DateTime(date, start_time)
+
+    end_col = _first_present_column(row, end_cols)
+    duration_col = _first_present_column(row, duration_cols)
+
+    end_dt =
+        if end_col !== nothing
+            end_time = _parse_time_strict(getproperty(row, end_col), String(end_col))
+            dt = Dates.DateTime(date, end_time)
+            if dt < start_dt
+                if allow_end_rollover
+                    dt += Dates.Day(1)
+                else
+                    error("end is before start at row $(index)")
+                end
+            end
+            dt
+        elseif duration_col !== nothing
+            secs = positive_duration_seconds(getproperty(row, duration_col); field_name=String(duration_col))
+            start_dt + Dates.Millisecond(round(Int, secs * 1000.0))
+        else
+            start_dt + Dates.Millisecond(round(Int, default_duration_seconds * 1000.0))
+        end
+
+    end_dt > start_dt || error("end is before start at row $(index)")
+    return start_dt, end_dt
+end
+
+"""
+    check_non_overlapping_timesteps(rows; kwargs...)
+
+Validate that each timestep starts at or after the previous timestep end.
+Throws an error on the first overlap.
+"""
+function check_non_overlapping_timesteps(rows; kwargs...)
+    prev_end = nothing
+    for (i, row) in enumerate(rows)
+        start_dt, end_dt = row_datetime_interval(row; index=i, kwargs...)
+        if prev_end !== nothing && start_dt < prev_end
+            error("overlapping timesteps at row $(i)")
+        end
+        prev_end = end_dt
+    end
+    return nothing
+end
+
+"""
+    select_overlapping_timesteps(rows, start_dt, end_dt; closed=true, kwargs...)
+
+Return rows whose timestep interval overlaps `[start_dt, end_dt]` (`closed=true`)
+or `(start_dt, end_dt)` (`closed=false`).
+"""
+function select_overlapping_timesteps(
+    rows,
+    start_dt::Dates.DateTime,
+    end_dt::Dates.DateTime;
+    closed::Bool=true,
+    kwargs...,
+)
+    end_dt >= start_dt || error("invalid range: end datetime is before start datetime")
+    out = Vector{eltype(rows)}()
+    for (i, row) in enumerate(rows)
+        s, e = row_datetime_interval(row; index=i, kwargs...)
+        overlaps = closed ? (s <= end_dt && e >= start_dt) : (s < end_dt && e > start_dt)
+        overlaps && push!(out, row)
+    end
+    return out
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ using Documenter # for doctests
         include("test-read_weather.jl")
     end
 
+    @testset "timestep intervals" begin
+        include("test-timestep_intervals.jl")
+    end
+
     @testset "write_weather()" begin
         include("test-write_weather.jl")
     end

--- a/test/test-read_weather.jl
+++ b/test/test-read_weather.jl
@@ -22,4 +22,31 @@ var_names = Dict(:temperature => :T, :relativeHumidity => :Rh, :wind => :Wind, :
         "use" => [:clearness],
         "file" => file,
     )
+
+    # ARCHIMED-like date encoding: first row has date, following rows can omit it.
+    tmp = mktempdir()
+    archimed_like = joinpath(tmp, "meteo.csv")
+    open(archimed_like, "w") do io
+        write(
+            io,
+            """
+            date;hour_start;hour_end;temperature;relativeHumidity;wind;clearness
+            2016/06/12;08:30:00;09:00:00;25;60;1.0;0.6
+            ;09:00:00;09:30:00;25;60;1.0;0.6
+            ;09:30:00;10:00:00;25;60;1.0;0.6
+            """
+        )
+    end
+
+    meteo_archimed = read_weather(
+        archimed_like,
+        :temperature => :T,
+        :relativeHumidity => (x -> x ./ 100) => :Rh,
+        :wind => :Wind,
+        date_formats=(DateFormat("yyyy/mm/dd"), DateFormat("yyyy-mm-dd")),
+        forward_fill_date=true,
+    )
+    @test meteo_archimed.date[1] == DateTime(2016, 6, 12, 8, 30, 0)
+    @test meteo_archimed.date[2] == DateTime(2016, 6, 12, 9, 0, 0)
+    @test meteo_archimed.date[3] == DateTime(2016, 6, 12, 9, 30, 0)
 end;

--- a/test/test-timestep_intervals.jl
+++ b/test/test-timestep_intervals.jl
@@ -1,0 +1,28 @@
+@testset "timestep interval helpers" begin
+    row1 = (date="2016/06/12", hour_start="08:30:00", hour_end="09:00:00")
+    row2 = (date="2016/06/12", hour_start="09:00:00", hour_end="09:30:00")
+    row_overlap = (date="2016/06/12", hour_start="08:45:00", hour_end="09:15:00")
+
+    s1, e1 = row_datetime_interval(row1)
+    @test s1 == DateTime(2016, 6, 12, 8, 30, 0)
+    @test e1 == DateTime(2016, 6, 12, 9, 0, 0)
+
+    s2, e2 = row_datetime_interval((date="2016/06/12", hour_start="09:00:00", step_duration="00:30:00"))
+    @test s2 == DateTime(2016, 6, 12, 9, 0, 0)
+    @test e2 == DateTime(2016, 6, 12, 9, 30, 0)
+
+    @test duration_seconds("00:30:00") == 1800.0
+    @test positive_duration_seconds(900.0) == 900.0
+    @test_throws ErrorException positive_duration_seconds("0")
+
+    check_non_overlapping_timesteps([row1, row2])
+    @test_throws ErrorException check_non_overlapping_timesteps([row1, row_overlap])
+
+    selected = select_overlapping_timesteps(
+        [row1, row2],
+        DateTime(2016, 6, 12, 9, 0, 0),
+        DateTime(2016, 6, 12, 9, 0, 0);
+        closed=true,
+    )
+    @test length(selected) == 2
+end


### PR DESCRIPTION
- Chronology validation with `row_datetime_interval`, `check_non_overlapping_timesteps`, and `select_overlapping_timesteps`
- Implement forward-fill for missing dates for `read_weather`
- Add `date_formats` arg to `read_weather` as a fallback date formats tried after `date_format`